### PR TITLE
Replace all Tie::IxHash w/ Hash::Ordered

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -16,6 +16,6 @@ requires 'Storable';
 requires 'strict';
 requires 'Test::Most';
 requires 'Text::Table::Tiny';
-requires 'Tie::IxHash';
+requires 'Hash::Ordered';
 requires 'Try::Tiny';
 requires 'warnings';

--- a/lib/Hash/Ordered/Extension.pm
+++ b/lib/Hash/Ordered/Extension.pm
@@ -1,20 +1,21 @@
-package Tie::IxHash::Extension;
+package Hash::Ordered::Extension;
 
 use strict;
 use warnings;
 use List::AllUtils;
 
 {
-package Tie::IxHash;
+package Hash::Ordered;
 
 use constant ERROR_KEY_LENGTH_MISMATCH => "incorrect number of keys";
 
 sub RenameKeys {
 	my ($self, @names) = @_;
-	die ERROR_KEY_LENGTH_MISMATCH if @names != $self->Length;
-	my @values = $self->Values;
+	die ERROR_KEY_LENGTH_MISMATCH if @names != $self->keys;
+	my @values = $self->values;
 	my @new_kv = List::AllUtils::mesh( @names, @values );
-	$self->Splice(0, $self->Length, @new_kv);
+	$self->clear;
+	$self->push(@new_kv);
 }
 
 

--- a/lib/PDL/Role/Enumerable.pm
+++ b/lib/PDL/Role/Enumerable.pm
@@ -3,15 +3,15 @@ package PDL::Role::Enumerable;
 use strict;
 use warnings;
 
-use Tie::IxHash;
-use Tie::IxHash::Extension;
+use Hash::Ordered;
+use Hash::Ordered::Extension;
 use Moo::Role;
 use Try::Tiny;
 use List::AllUtils ();
 
 with qw(PDL::Role::Stringifiable);
 
-has _levels => ( is => 'rw', default => sub { Tie::IxHash->new; } );
+has _levels => ( is => 'rw', default => sub { Hash::Ordered->new; } );
 
 sub element_stringify_max_width {
 	my ($self, $element) = @_;
@@ -23,12 +23,12 @@ sub element_stringify_max_width {
 
 sub element_stringify {
 	my ($self, $element) = @_;
-	( $self->_levels->Keys )[ $element ];
+	( $self->_levels->keys )[ $element ];
 }
 
 sub number_of_levels {
 	my ($self) = @_;
-	$self->_levels->Length;
+	scalar $self->_levels->keys;
 }
 
 sub levels {
@@ -37,10 +37,10 @@ sub levels {
 		try {
 			$self->_levels->RenameKeys( @levels );
 		} catch {
-			die "incorrect number of levels" if /@{[ Tie::IxHash::ERROR_KEY_LENGTH_MISMATCH ]}/;
+			die "incorrect number of levels" if /@{[ Hash::Ordered::ERROR_KEY_LENGTH_MISMATCH ]}/;
 		};
 	}
-	[ $self->_levels->Keys ];
+	[ $self->_levels->keys ];
 }
 
 around qw(slice uniq dice) => sub {


### PR DESCRIPTION
This is virtually a 1-to-1 replacement of `Tie::IxHash` with `Hash::Ordered`. Exception noted below.

All tests pass, but found that the Tie::IxHash solution was slightly faster when I did some benchmarks. If you could verify that with your own benchmarks that would be awesome. I don't have much experience benchmarking.

One possible hotspot in my changes is [Line #63](https://github.com/EntropyOrg/p5-Data-Frame/pull/21/files#diff-53a926e56170fa446dbde02c0a0a3af6R63) in `lib/PDL/Factor.pm`. I tried using `first_index` from `List::AllUtils` to replace the `Indices()` sub from `Tie::IxHash`, but couldn't because the `$_` inside `first_index`'s block interfered with `rmap`'s `$_`. `Hash::Ordered` doesn't have an equivalent for `Indices()`. 

Other implementation notes:
- `scalar $hash->keys` replaces `Tie::IxHash`'s `Length`
- `set()` replaces `Tie::IxHash`'s `Push`. `Hash::Ordered` does have a `push()` but `set()` was a closer match.
- We might want to think of another solution to creating `Hash::Ordered::Extension`. Creating a new package just to add a way to rename the keys seems a waste of the `Hash::Ordered::Extension` namespace.

Closes #15 

A [PR Challenge](http://cpan-prc.org/) entry. :)
