### PR TITLE
Exception objects (Pull Request Challenge January 2016)

### DIFF
--- a/lib/Data/Frame.pm
+++ b/lib/Data/Frame.pm
@@ -4,6 +4,8 @@ package Data::Frame;
 use strict;
 use warnings;
 
+use failures qw/columns::mismatch/;
+
 use Tie::IxHash;
 use Tie::IxHash::Extension;
 use PDL::Lite;
@@ -371,7 +373,15 @@ sub equal {
 			my @colspec = List::AllUtils::mesh( @colnames, @eq_cols );
 			return $self->new( columns => \@colspec );
 		} else {
-			die "number of columns is not equal: @{[$self->number_of_columns]} != @{[$other->number_of_columns]}";
+			failure::columns::mismatch->throw({
+					msg => "number of columns is not equal: @{[$self->number_of_columns]} != @{[$other->number_of_columns]}",
+					trace => failure->croak_trace,
+					playload => {
+						self_number_of_columns => $self->number_of_columns,
+						other_number_of_columns => $other->number_of_columns,
+					},
+				}
+			);
 		}
 	}
 }

--- a/lib/Data/Frame.pm
+++ b/lib/Data/Frame.pm
@@ -4,7 +4,12 @@ package Data::Frame;
 use strict;
 use warnings;
 
-use failures qw/columns::mismatch/;
+use failures qw{
+	columns::mismatch columns::length columns::unbalanced
+	rows::length rows::unique
+	column::exists column::name::string
+	index index::exists
+};
 
 use Tie::IxHash;
 use Tie::IxHash::Extension;
@@ -12,6 +17,7 @@ use PDL::Lite;
 use Data::Perl ();
 use List::AllUtils;
 use Try::Tiny;
+use Safe::Isa;
 use PDL::SV;
 use PDL::StringfiableExtension;
 use Carp;
@@ -159,8 +165,14 @@ the last column).
 # supports negative indices
 sub nth_column {
 	my ($self, $index) = @_;
-	confess "requires index" unless defined $index;
-	confess "column index out of bounds" if $index >= $self->number_of_columns;
+	failure::index->throw({
+			msg => "requires index",
+			trace => failure->croak_trace
+		}) unless defined $index;
+	failure::index::exists->throw({
+			msg => "column index out of bounds",
+			trace => failure->croak_trace,
+		}) if $index >= $self->number_of_columns;
 	# fine if $index < 0 because negative indices are supported
 	$self->_columns->Values( $index );
 }
@@ -184,7 +196,10 @@ sub column_names {
 		try {
 			$self->_columns->RenameKeys( @colnames );
 		} catch {
-			confess "incorrect number of column names" if /@{[ Tie::IxHash::ERROR_KEY_LENGTH_MISMATCH ]}/;
+			failure::columns::length->throw({
+					msg => "incorrect number of column names",
+					trace => failure->croak_trace,
+				}) if $_->$_isa('failure::keys::number');
 		};
 	}
 	[ $self->_columns->Keys ];
@@ -224,10 +239,14 @@ sub row_names {
 			$new_rows = Data::Perl::array(@rest);
 		}
 
-		confess "invalid row names length"
-			if $self->number_of_rows != $new_rows->count;
-		confess "non-unique row names"
-			if $new_rows->count != $new_rows->uniq->count;
+		failure::rows::length->throw({
+				msg => "invalid row names length",
+				trace => failure->croak_trace,
+			}) if $self->number_of_rows != $new_rows->count;
+		failure::rows::unique->throw({
+				msg => "non-unique row names",
+				trace => failure->croak_trace,
+			}) if $new_rows->count != $new_rows->uniq->count;
 
 		return $self->_row_names( PDL::SV->new($new_rows) );
 	}
@@ -255,18 +274,27 @@ Returns the column with the name C<$column_name>.
 =cut
 sub column {
 	my ($self, $colname) = @_;
-	confess "column $colname does not exist" unless $self->_columns->EXISTS( $colname );
+	failure::column::exists->throw({
+			msg => "column $colname does not exist",
+			trace => failure->croak_trace,
+		}) unless $self->_columns->EXISTS( $colname );
 	$self->_columns->FETCH( $colname );
 }
 
 sub _column_validate {
 	my ($self, $name, $data) = @_;
 	if( $name =~ /^\d+$/  ) {
-		confess "invalid column name: $name can not be an integer";
+		failure::column::name::string->throw({
+				msg => "invalid column name: $name can not be an integer",
+				trace => failure->croak_trace,
+			});
 	}
 	if( $self->number_of_columns ) {
 		if( $data->number_of_rows != $self->number_of_rows ) {
-			confess "number of rows in column is @{[ $data->number_of_rows ]}; expected @{[ $self->number_of_rows ]}";
+			failure::rows::length->throw({
+					msg => "number of rows in column is @{[ $data->number_of_rows ]}; expected @{[ $self->number_of_rows ]}",
+					trace => failure->croak_trace,
+				});
 		}
 	}
 	1;
@@ -281,7 +309,10 @@ Adds all the columns in C<@column_pairlist> to the C<Data::Frame>.
 =cut
 sub add_columns {
 	my ($self, @columns) = @_;
-	confess "uneven number of elements for column specification" unless @columns % 2 == 0;
+	failure::columns::unbalanced->throw({
+			msg => "uneven number of elements for column specification",
+			trace => failure->croak_trace,
+		}) unless @columns % 2 == 0;
 	for ( List::AllUtils::pairs(@columns) ) {
 		my ( $name, $data ) = @$_;
 		$self->add_column( $name => $data );
@@ -298,8 +329,10 @@ C<$data>.
 =cut
 sub add_column {
 	my ($self, $name, $data) = @_;
-	confess "column $name already exists"
-		if $self->_columns->EXISTS( $name );
+	failure::column::exists->throw({
+			msg => "column $name already exists",
+			trace => failure->croak_trace,
+		}) if $self->_columns->EXISTS( $name );
 
 	# TODO apply column role to data
 	$data = PDL::SV->new( $data ) if ref $data eq 'ARRAY';

--- a/lib/PDL/Factor.pm
+++ b/lib/PDL/Factor.pm
@@ -3,6 +3,8 @@ package PDL::Factor;
 use strict;
 use warnings;
 
+use failures qw/levels::mismatch/;
+
 use Moo;
 use PDL::Lite;
 use Tie::IxHash;
@@ -114,7 +116,15 @@ sub equal {
 			return $self->{PDL} == $other->{PDL};
 			# TODO return a PDL::Logical
 		} else {
-			die "level sets of factors are different";
+			failure::levels::mismatch->throw({
+					msg => "level sets of factors are different",
+					trace => failure->croak_trace,
+					payload => {
+						self_levels => $self->_levels,
+						other_levels => $other->_levels,
+					}
+				}
+			);
 		}
 	} else {
 		# TODO hacky. need to test this more

--- a/lib/PDL/Role/Enumerable.pm
+++ b/lib/PDL/Role/Enumerable.pm
@@ -3,10 +3,13 @@ package PDL::Role::Enumerable;
 use strict;
 use warnings;
 
+use failures qw/levels::number/;
+
 use Tie::IxHash;
 use Tie::IxHash::Extension;
 use Moo::Role;
 use Try::Tiny;
+use Safe::Isa;
 use List::AllUtils ();
 
 with qw(PDL::Role::Stringifiable);
@@ -37,7 +40,11 @@ sub levels {
 		try {
 			$self->_levels->RenameKeys( @levels );
 		} catch {
-			die "incorrect number of levels" if /@{[ Tie::IxHash::ERROR_KEY_LENGTH_MISMATCH ]}/;
+			failure::levels::number->throw({
+					msg => "incorrect number of levels",
+					trace => failure->croak_trace,
+				}
+			) if $_->$_isa('failure::keys::number');
 		};
 	}
 	[ $self->_levels->Keys ];

--- a/lib/Tie/IxHash/Extension.pm
+++ b/lib/Tie/IxHash/Extension.pm
@@ -7,11 +7,11 @@ use List::AllUtils;
 {
 package Tie::IxHash;
 
-use constant ERROR_KEY_LENGTH_MISMATCH => "incorrect number of keys";
+use failures qw/keys::number/;
 
 sub RenameKeys {
 	my ($self, @names) = @_;
-	die ERROR_KEY_LENGTH_MISMATCH if @names != $self->Length;
+	failure::keys::number->throw if @names != $self->Length;
 	my @values = $self->Values;
 	my @new_kv = List::AllUtils::mesh( @names, @values );
 	$self->Splice(0, $self->Length, @new_kv);

--- a/t/failures.t
+++ b/t/failures.t
@@ -6,19 +6,50 @@ use Test::More;
 use Data::Frame;
 use Test::Fatal;
 
-my $a = Data::Frame->new( columns => [
-		x => [ qw/foo br baz/ ],
-	],
-);
-
-my $b = Data::Frame->new( columns => [
-		x => [qw/ a b c /],
-		y => [1..3],
-	],
-);
+use PDL::Factor;
 
 
-isa_ok( exception { $a == $b }, 'failure::columns::mismatch');
+subtest 'Data::Frame throws exception objects' => sub {
 
+	my $a = Data::Frame->new( columns => [
+			x => [ qw/foo br baz/ ],
+		],
+	);
+
+	my $b = Data::Frame->new( columns => [
+			x => [qw/ a b c /],
+			y => [1..3],
+		],
+	);
+
+
+	isa_ok( exception { $a == $b }, 'failure::columns::mismatch' );
+
+	isa_ok( exception { $a->column_names(qw/a b/) }, 'failure::columns::length' );
+
+	isa_ok( exception { $a->row_names(qw/a b/) }, 'failure::rows::length' );
+	isa_ok( exception { $a->row_names(qw/a b b/) }, 'failure::rows::unique' );
+
+	isa_ok( exception { $a->column('ape') }, 'failure::column::exists' );
+
+	isa_ok( exception { $a->nth_column }, 'failure::index' );
+	isa_ok( exception { $a->nth_column(5) }, 'failure::index::exists' );
+
+	isa_ok( exception { $a->add_column(1) }, 'failure::column::name::string' );
+	isa_ok( exception { $a->add_column(c => [1..4]) }, 'failure::rows::length' );
+	isa_ok( exception { $a->add_column('x') }, 'failure::column::exists' );
+
+	isa_ok( exception { $a->add_columns(x => [1..3], 'y') }, 'failure::columns::unbalanced' );
+};
+
+subtest 'PDL::Factor throws exception objects' => sub {
+	my $a = PDL::Factor->new(integer => 1, levels => [qw/a b c/],);
+	my $b = PDL::Factor->new(integer => 1, levels => [qw/c b a/],);
+
+	isa_ok( exception { $a == $b }, 'failure::levels::mismatch' );
+
+
+	isa_ok( exception { $a->levels(qw/a b c d/) }, 'failure::levels::number' );
+};
 done_testing;
 

--- a/t/failures.t
+++ b/t/failures.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+
+use strict; use warnings;
+use Test::More;
+
+use Data::Frame;
+use Test::Fatal;
+
+my $a = Data::Frame->new( columns => [
+		x => [ qw/foo br baz/ ],
+	],
+);
+
+my $b = Data::Frame->new( columns => [
+		x => [qw/ a b c /],
+		y => [1..3],
+	],
+);
+
+
+isa_ok( exception { $a == $b }, 'failure::columns::mismatch');
+
+done_testing;
+


### PR DESCRIPTION
The naming of exceptions is not consistent now, and I am struggling to come up with good names, so if anyone else has ideas for what is best naming policy, that would be great. I was struggling between naming for expected behaviour or naming for what the error is, while trying to keep them short.

The test for `Tie::IxHash::Extension` throwing an exception object, is that the code that uses it still survives and throws it's exceptions in the correct ways.

I uses `Safe::Isa` since that is what `failures` recommends.

The code gets a bit bigger with this, and I am not sure the payload is necessary, but I do think adding the trace is a good idea. I added the payload mostly to show how it's done for later.

This attempts to address the second issue outlined in #20.
