### PR TITLE
speed up PDL::SV->new

### DIFF
--- a/lib/PDL/SV.pm
+++ b/lib/PDL/SV.pm
@@ -36,7 +36,7 @@ around new => sub {
 
 	my $nelem = $self->nelem;
 	for my $idx (0..$nelem-1) {
-		my @where = PDL::Core::pdl($self->one2nd($idx))->list;
+		my @where = map { $_->list } $self->one2nd($idx);
 		$self->_internal()->[$idx] = $self->_array_get( $data, @where );
 	}
 


### PR DESCRIPTION
This avoids one pdl creation per array element. On my machine this change reduces below code time from 4.2sec to 3.5 sec (17% faster).

    use PDL::SV;
    PDL::SV->new([ 0 .. 100000 ]);